### PR TITLE
Sixel VT sequence Step 1. Allow pass-through on Windows

### DIFF
--- a/terminal/sixel.go
+++ b/terminal/sixel.go
@@ -17,7 +17,10 @@ func sixelHandler(pty chan rune, terminal *Terminal) error {
 	for {
 		b := <-pty
 		if b == 0x1b { // terminated by ESC bell or ESC \
-			_ = <-pty // swallow \ or bell
+			t := <-pty
+			if t != 0x07 && t != 0x5c {
+				return fmt.Errorf("Incorrect terminator in sixel sequence: 0x%02X [%c]", t, t)
+			}
 			break
 		}
 		if b >= 33 {


### PR DESCRIPTION
## Description

Allows VT sequences to pass through by changing Windows Console Mode default settings.

Fixes #5 (partially)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`type example.sixel` will now hit a breakpoint in `sixelHandler()`

**Test Configuration**:
* OS: Windows
* OS version: 1809

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
