### PR TITLE
introduced different sets of OSC terminators for Unix and Windows

### DIFF
--- a/platform/interfaces.go
+++ b/platform/interfaces.go
@@ -17,4 +17,5 @@ type Pty interface {
 
 	Resize(x int, y int) error
 	CreateGuestProcess(imagePath string) (Process, error)
+	GetPlatformDependentSettings() PlatformDependentSettings
 }

--- a/platform/settings.go
+++ b/platform/settings.go
@@ -1,0 +1,6 @@
+package platform
+
+// PlatformDependentSettings Settings specific to the platform
+type PlatformDependentSettings struct {
+	OSCTerminators map[rune]struct{}
+}

--- a/platform/unixpty.go
+++ b/platform/unixpty.go
@@ -13,8 +13,9 @@ import (
 )
 
 type unixPty struct {
-	pty *os.File
-	tty *os.File
+	pty                       *os.File
+	tty                       *os.File
+	platformDependentSettings PlatformDependentSettings
 }
 
 type winsize struct {
@@ -81,6 +82,10 @@ func (p *unixPty) CreateGuestProcess(imagePath string) (Process, error) {
 	return shell, nil
 }
 
+func (pty *unixPty) GetPlatformDependentSettings() PlatformDependentSettings {
+	return pty.platformDependentSettings
+}
+
 func NewPty(x, y int) (Pty, error) {
 	innerPty, innerTty, err := pty.Open()
 	if err != nil {
@@ -89,5 +94,8 @@ func NewPty(x, y int) (Pty, error) {
 	return &unixPty{
 		pty: innerPty,
 		tty: innerTty,
+		platformDependentSettings: PlatformDependentSettings{
+			OSCTerminators: map[rune]struct{}{0x07: {}, 0x5c: {}},
+		},
 	}, nil
 }

--- a/platform/winpty.go
+++ b/platform/winpty.go
@@ -92,11 +92,12 @@ func init() {
 }
 
 type winConPty struct {
-	inPipe       syscall.Handle
-	outPipe      syscall.Handle
-	innerInPipe  syscall.Handle
-	innerOutPipe syscall.Handle
-	hcon         uintptr
+	inPipe                    syscall.Handle
+	outPipe                   syscall.Handle
+	innerInPipe               syscall.Handle
+	innerOutPipe              syscall.Handle
+	hcon                      uintptr
+	platformDependentSettings PlatformDependentSettings
 }
 
 func (pty *winConPty) Read(p []byte) (n int, err error) {
@@ -181,6 +182,10 @@ func (pty *winConPty) Resize(x, y int) error {
 	return nil
 }
 
+func (pty *winConPty) GetPlatformDependentSettings() PlatformDependentSettings {
+	return pty.platformDependentSettings
+}
+
 // NewPty creates a new instance of a Pty implementation for Windows on a newly allocated ConPTY
 func NewPty(x, y int) (pty Pty, err error) {
 	if !ptyInitSucceeded {
@@ -217,6 +222,9 @@ func NewPty(x, y int) (pty Pty, err error) {
 		innerInPipe:  inputReadSide,
 		innerOutPipe: outputWriteSide,
 		hcon:         uintptr(hc),
+		platformDependentSettings: PlatformDependentSettings{
+			OSCTerminators: map[rune]struct{}{0x00: {}},
+		},
 	}
 
 	return pty, nil

--- a/terminal/osc.go
+++ b/terminal/osc.go
@@ -12,7 +12,7 @@ func oscHandler(pty chan rune, terminal *Terminal) error {
 
 	for {
 		b := <-pty
-		if b == 0x07 || b == 0x5c {
+		if terminal.IsOSCTerminator(b) {
 			params = append(params, param)
 			break
 		}

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -30,23 +30,24 @@ const (
 )
 
 type Terminal struct {
-	program            uint32
-	buffers            []*buffer.Buffer
-	activeBuffer       *buffer.Buffer
-	lock               sync.Mutex
-	pty                platform.Pty
-	logger             *zap.SugaredLogger
-	title              string
-	size               Winsize
-	config             *config.Config
-	titleHandlers      []chan bool
-	modes              Modes
-	mouseMode          MouseMode
-	bracketedPasteMode bool
-	isDirty            bool
-	charWidth          float32
-	charHeight         float32
-	lastBuffer         uint8
+	program                   uint32
+	buffers                   []*buffer.Buffer
+	activeBuffer              *buffer.Buffer
+	lock                      sync.Mutex
+	pty                       platform.Pty
+	logger                    *zap.SugaredLogger
+	title                     string
+	size                      Winsize
+	config                    *config.Config
+	titleHandlers             []chan bool
+	modes                     Modes
+	mouseMode                 MouseMode
+	bracketedPasteMode        bool
+	isDirty                   bool
+	charWidth                 float32
+	charHeight                float32
+	lastBuffer                uint8
+	platformDependentSettings platform.PlatformDependentSettings
 }
 
 type Modes struct {
@@ -85,6 +86,7 @@ func New(pty platform.Pty, logger *zap.SugaredLogger, config *config.Config) *Te
 		modes: Modes{
 			ShowCursor: true,
 		},
+		platformDependentSettings: pty.GetPlatformDependentSettings(),
 	}
 	t.activeBuffer = t.buffers[0]
 	return t
@@ -119,6 +121,11 @@ func (terminal *Terminal) SetMouseMode(mode MouseMode) {
 
 func (terminal *Terminal) GetMouseMode() MouseMode {
 	return terminal.mouseMode
+}
+
+func (terminal *Terminal) IsOSCTerminator(char rune) bool {
+	_, ok := terminal.platformDependentSettings.OSCTerminators[char]
+	return ok
 }
 
 func (terminal *Terminal) UseMainBuffer() {


### PR DESCRIPTION
## Description

Terminal now correctly interprets NUL-terminated OSC sequence sent by Windows

Fixes #2 and sets the correct title of the terminal window

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] On startup of aminal under Windows, the path to cmd.exe shows in the window title.
- [ ] On startup under Linux, the behaviour is unchanged

**Test Configuration**:
* OS: Windows 10
* OS version: 1809
* Go version: 1.11.2 windows/amd64

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
