### PR TITLE
updated riywo/loginshell package (to fetch actual shell launcher)

### DIFF
--- a/vendor/github.com/riywo/loginshell/loginshell_test.go
+++ b/vendor/github.com/riywo/loginshell/loginshell_test.go
@@ -4,6 +4,7 @@ import (
     "testing"
     "os"
     "fmt"
+    "runtime"
 )
 
 func TestShell(t *testing.T) {
@@ -12,8 +13,14 @@ func TestShell(t *testing.T) {
         t.Error(err)
     }
 
-    currentShell := os.Getenv("SHELL")
-    if shell != currentShell {
-        t.Error(fmt.Sprintf("Output: %s, Current login shell: %s", shell, currentShell))
+    if runtime.GOOS == "windows" {
+        if shell == "" {
+            t.Error("Output is empty!")
+        }
+    } else {
+        currentShell := os.Getenv("SHELL")
+        if shell != currentShell {
+            t.Error(fmt.Sprintf("Output: %s, Current login shell: %s", shell, currentShell))
+        }
     }
 }


### PR DESCRIPTION
## Description

Take console executable from COMSPEC environment variable 

Fixes #3

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Run `aminal.exe` on Windows and `cmd.exe` starts inside the terminal window.

**Test Configuration**:
* OS: Windows 10
* OS version: 1809
* Go version: 1.11

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
